### PR TITLE
Create data model and migrations in authorization-service

### DIFF
--- a/app/Enum/InstitutionUserStatusKey.php
+++ b/app/Enum/InstitutionUserStatusKey.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enum;
+
+enum InstitutionUserStatusKey: string
+{
+    case Created = 'CREATED';
+    case Activated = 'ACTIVATED';
+    case Deactivated = 'DEACTIVATED';
+}

--- a/app/Enum/PrivilegeKey.php
+++ b/app/Enum/PrivilegeKey.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Enum;
+
+enum PrivilegeKey: string
+{
+    case AddRole = 'ADD_ROLE';
+    case ViewRole = 'VIEW_ROLE';
+    case EditRole = 'EDIT_ROLE';
+    case DeleteRole = 'DELETE_ROLE';
+    case AddUser = 'ADD_USER';
+    case EditUser = 'EDIT_USER';
+    case ViewUser = 'VIEW_USER';
+    case ExportUser = 'EXPORT_USER';
+    case ActivateUser = 'ACTIVATE_USER';
+    case DeactivateUser = 'DEACTIVATE_USER';
+    case ArchiveUser = 'ARCHIVE_USER';
+}

--- a/app/Models/Institution.php
+++ b/app/Models/Institution.php
@@ -3,16 +3,21 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Foundation\Auth\User as Authenticatable;
 
-class User extends Authenticatable
+class Institution extends Model
 {
     use HasFactory, SoftDeletes;
 
     public function institutionUsers(): HasMany
     {
         return $this->hasMany(InstitutionUser::class);
+    }
+
+    public function roles(): HasMany
+    {
+        return $this->hasMany(Role::class);
     }
 }

--- a/app/Models/InstitutionUser.php
+++ b/app/Models/InstitutionUser.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class InstitutionUser extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    public function institution(): BelongsTo
+    {
+        return $this->belongsTo(Institution::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function institutionUserRoles(): HasMany
+    {
+        return $this->hasMany(InstitutionUserRole::class);
+    }
+
+    public function institutionUserStatus(): BelongsTo
+    {
+        return $this->belongsTo(InstitutionUserStatus::class);
+    }
+}

--- a/app/Models/InstitutionUserRole.php
+++ b/app/Models/InstitutionUserRole.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class InstitutionUserRole extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    public function institutionUser(): BelongsTo
+    {
+        return $this->belongsTo(InstitutionUser::class);
+    }
+
+    public function role(): BelongsTo
+    {
+        return $this->belongsTo(Role::class);
+    }
+}

--- a/app/Models/InstitutionUserStatus.php
+++ b/app/Models/InstitutionUserStatus.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use App\Enum\InstitutionUserStatusKey;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class InstitutionUserStatus extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = ['key'];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, mixed>
+     */
+    protected $casts = [
+        'key' => InstitutionUserStatusKey::class,
+    ];
+
+    public function institutionUsers(): HasMany
+    {
+        return $this->hasMany(InstitutionUser::class);
+    }
+}

--- a/app/Models/Privilege.php
+++ b/app/Models/Privilege.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use App\Enum\PrivilegeKey;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Privilege extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = ['key'];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'key' => PrivilegeKey::class,
+    ];
+
+    public function rolePrivileges(): HasMany
+    {
+        return $this->hasMany(PrivilegeRole::class);
+    }
+}

--- a/app/Models/PrivilegeRole.php
+++ b/app/Models/PrivilegeRole.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class PrivilegeRole extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    public function role(): BelongsTo
+    {
+        return $this->belongsTo(Role::class);
+    }
+
+    public function privilege(): BelongsTo
+    {
+        return $this->belongsTo(Privilege::class);
+    }
+}

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Role extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    public function institutionUserRoles(): HasMany
+    {
+        return $this->hasMany(InstitutionUserRole::class);
+    }
+
+    public function rolePrivileges(): HasMany
+    {
+        return $this->hasMany(PrivilegeRole::class);
+    }
+
+    public function institution(): BelongsTo
+    {
+        return $this->belongsTo(Institution::class);
+    }
+}

--- a/app/Providers/FakerServiceProvider.php
+++ b/app/Providers/FakerServiceProvider.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Providers;
+
+use Faker\Factory;
+use Faker\Generator;
+use Faker\Provider\Base;
+use Illuminate\Support\ServiceProvider;
+
+class FakerServiceProvider extends ServiceProvider
+{
+    /**
+     * Generated using https://www.olivereivak.com/isikukood.html
+     */
+    public final const ESTONIAN_PIC_EXAMPLES = [
+        '47607239590',
+        '60505059544',
+        '38804045250',
+        '49511044258',
+        '61912049562',
+        '35307284287',
+        '61911182720',
+        '34509144746',
+        '50608024740',
+        '43912095240',
+        '33904113735',
+        '34507013712',
+        '61607075277',
+        '48110193735',
+        '60902195205',
+        '43602275770',
+        '34911206063',
+        '33408242792',
+        '50301024958',
+        '43410212286',
+        '36010273790',
+        '36610200191',
+        '47012094714',
+        '62207160033',
+        '47507130084',
+        '61408270284',
+        '38104136520',
+        '47109194242',
+        '51309160119',
+        '43503304242',
+        '61501250086',
+        '49311255780',
+        '44509067055',
+        '50211093727',
+        '49406184952',
+        '43610284763',
+        '33811094234',
+        '44208104267',
+        '32505260024',
+        '50401080067',
+        '44809060035',
+        '48609126030',
+        '60409012227',
+        '47103125760',
+    ];
+
+    /**
+     * Register services.
+     */
+    public function register(): void
+    {
+        $this->app->singleton(Generator::class, function () {
+            $faker = Factory::create();
+            $faker->addProvider(new class($faker) extends Base
+            {
+                public function estonianPIC(): string
+                {
+                    return $this->generator
+                        ->randomElement(FakerServiceProvider::ESTONIAN_PIC_EXAMPLES);
+                }
+            });
+
+            return $faker;
+        });
+    }
+
+    /**
+     * Bootstrap services.
+     */
+    public function boot(): void
+    {
+        //
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -194,6 +194,7 @@ return [
         // App\Providers\BroadcastServiceProvider::class,
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
+        App\Providers\FakerServiceProvider::class,
 
     ],
 

--- a/database/factories/InstitutionFactory.php
+++ b/database/factories/InstitutionFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Institution;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Institution>
+ */
+class InstitutionFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->company(),
+        ];
+    }
+}

--- a/database/factories/InstitutionUserFactory.php
+++ b/database/factories/InstitutionUserFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enum\InstitutionUserStatusKey;
+use App\Models\Institution;
+use App\Models\InstitutionUserStatus;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\InstitutionUser>
+ */
+class InstitutionUserFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'institution_id' => Institution::factory(),
+            'user_id' => User::factory(),
+            'institution_user_status_id' => fn () => InstitutionUserStatus::where('key', InstitutionUserStatusKey::Created->value)
+                    ->first(),
+        ];
+    }
+}

--- a/database/factories/InstitutionUserRoleFactory.php
+++ b/database/factories/InstitutionUserRoleFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\InstitutionUser;
+use App\Models\Role;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\InstitutionUserRole>
+ */
+class InstitutionUserRoleFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'institution_user_id' => InstitutionUser::factory(),
+            'role_id' => Role::factory(),
+        ];
+    }
+}

--- a/database/factories/PrivilegeFactory.php
+++ b/database/factories/PrivilegeFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Privilege>
+ */
+class PrivilegeFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/database/factories/PrivilegeRoleFactory.php
+++ b/database/factories/PrivilegeRoleFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enum\PrivilegeKey;
+use App\Models\Privilege;
+use App\Models\PrivilegeRole;
+use App\Models\Role;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PrivilegeRole>
+ */
+class PrivilegeRoleFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'role_id' => Role::factory(),
+            'privilege_id' => fn () => Privilege::where('key', PrivilegeKey::AddUser->value)->first(),
+        ];
+    }
+}

--- a/database/factories/RoleFactory.php
+++ b/database/factories/RoleFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Institution;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Role>
+ */
+class RoleFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->jobTitle(),
+            'institution_id' => Institution::factory(),
+        ];
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,13 +2,17 @@
 
 namespace Database\Factories;
 
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Foundation\Testing\WithFaker;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
+ * @extends Factory<User>
  */
 class UserFactory extends Factory
 {
+    use WithFaker;
+
     /**
      * Define the model's default state.
      *
@@ -17,6 +21,9 @@ class UserFactory extends Factory
     public function definition(): array
     {
         return [
+            'forename' => $this->faker->firstName(),
+            'surname' => $this->faker->lastName(),
+            'personal_identification_code' => $this->faker->unique()->estonianPIC(),
         ];
     }
 }

--- a/database/migrations/2023_03_23_153304_create_users_table.php
+++ b/database/migrations/2023_03_23_153304_create_users_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->softDeletesTz();
+            $table->timestampsTz();
+            $table->text('forename');
+            $table->text('surname');
+            $table->text('personal_identification_code')->unique();
+            $table->comment(
+                'Table storing physical persons, referred to as users. '.
+                'Users belong to one or more institutions.'
+            );
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('users');
+    }
+};

--- a/database/migrations/2023_03_23_163304_create_institutions_table.php
+++ b/database/migrations/2023_03_23_163304_create_institutions_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('institutions', function (Blueprint $table) {
+            $table->id();
+            $table->softDeletesTz();
+            $table->timestampsTz();
+            $table->text('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('institutions');
+    }
+};

--- a/database/migrations/2023_03_23_173246_create_roles_table.php
+++ b/database/migrations/2023_03_23_173246_create_roles_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Models\Institution;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->timestampsTz();
+            $table->softDeletesTz();
+            $table->foreignIdFor(Institution::class);
+            $table->text('name');
+            $table->comment(
+                'Roles are a grouping of privileges. '.
+                'Roles always belong to an institution. '.
+                'Roles are not meant to be used for authorization directly.'
+            );
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('roles');
+    }
+};

--- a/database/migrations/2023_03_23_173446_create_institution_user_statuses_table.php
+++ b/database/migrations/2023_03_23_173446_create_institution_user_statuses_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Models\InstitutionUserStatus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const KEYS = [
+        'CREATED',
+        'ACTIVATED',
+        'DEACTIVATED',
+    ];
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('institution_user_statuses', function (Blueprint $table) {
+            $table->id();
+            $table->timestampsTz();
+            $table->softDeletesTz();
+            $table->text('key');
+            $table->comment('Lookup table storing the set of valid values for institution_user.status');
+        });
+
+        collect(self::KEYS)
+            ->map(fn ($key) => new InstitutionUserStatus(['key' => $key]))
+            ->each(fn ($model) => $model->save());
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('institution_user_statuses');
+    }
+};

--- a/database/migrations/2023_03_23_174541_create_institution_users_table.php
+++ b/database/migrations/2023_03_23_174541_create_institution_users_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Models\Institution;
+use App\Models\InstitutionUserStatus;
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('institution_users', function (Blueprint $table) {
+            $table->id();
+            $table->timestampsTz();
+            $table->softDeletesTz();
+            $table->foreignIdFor(Institution::class);
+            $table->foreignIdFor(User::class);
+            $table->foreignIdFor(InstitutionUserStatus::class);
+            $table->unique(['institution_id', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('institution_users');
+    }
+};

--- a/database/migrations/2023_03_23_181633_create_institution_user_roles_table.php
+++ b/database/migrations/2023_03_23_181633_create_institution_user_roles_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use App\Models\InstitutionUser;
+use App\Models\Role;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('institution_user_roles', function (Blueprint $table) {
+            $table->id();
+            $table->timestampsTz();
+            $table->softDeletesTz();
+            $table->foreignIdFor(InstitutionUser::class);
+            $table->foreignIdFor(Role::class);
+            $table->unique(['institution_user_id', 'role_id']);
+            $table->comment(
+                'Roles are a grouping of privileges. '.
+                'Roles are not meant to be used for authorization directly.'
+            );
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('institution_user_roles');
+    }
+};

--- a/database/migrations/2023_03_23_182206_create_privilege_roles_table.php
+++ b/database/migrations/2023_03_23_182206_create_privilege_roles_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Models\Privilege;
+use App\Models\Role;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('privilege_roles', function (Blueprint $table) {
+            $table->id();
+            $table->timestampsTz();
+            $table->softDeletesTz();
+            $table->foreignIdFor(Privilege::class);
+            $table->foreignIdFor(Role::class);
+            $table->unique(['privilege_id', 'role_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('privilege_roles');
+    }
+};

--- a/database/migrations/2023_03_23_184640_create_privileges_table.php
+++ b/database/migrations/2023_03_23_184640_create_privileges_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use App\Models\Privilege;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const KEYS = [
+        'ADD_ROLE',
+        'VIEW_ROLE',
+        'EDIT_ROLE',
+        'DELETE_ROLE',
+        'ADD_USER',
+        'EDIT_USER',
+        'VIEW_USER',
+        'EXPORT_USER',
+        'ACTIVATE_USER',
+        'DEACTIVATE_USER',
+        'ARCHIVE_USER',
+    ];
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('privileges', function (Blueprint $table) {
+            $table->id();
+            $table->timestampsTz();
+            $table->softDeletesTz();
+            $table->text('key')->unique();
+            $table->text('description')->nullable();
+            $table->comment('A privilege authorizes the user to perform a set of actions');
+        });
+
+        collect(self::KEYS)
+            ->map(fn ($key) => new Privilege(['key' => $key]))
+            ->each(fn ($model) => $model->save());
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('privileges');
+    }
+};

--- a/tests/Feature/Models/Database/InstitutionTest.php
+++ b/tests/Feature/Models/Database/InstitutionTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Feature\Models\Database;
+
+use App\Models\Institution;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class InstitutionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_saving(): void
+    {
+        $createdModel = Institution::factory()->create();
+        $this->assertModelExists($createdModel);
+
+        $retrievedModel = Institution::findOrFail($createdModel->id);
+        $this->assertEquals($createdModel->name, $retrievedModel->name);
+    }
+}

--- a/tests/Feature/Models/Database/InstitutionUserRoleTest.php
+++ b/tests/Feature/Models/Database/InstitutionUserRoleTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Feature\Models\Database;
+
+use App\Models\Institution;
+use App\Models\InstitutionUser;
+use App\Models\InstitutionUserRole;
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class InstitutionUserRoleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_saving(): void
+    {
+        $createdModel = InstitutionUserRole::factory()->create();
+        $this->assertModelExists($createdModel);
+    }
+
+    public function test_referenced_rows_exist(): void
+    {
+        $expectedName = 'institution-user-role-test_test-institution-exists';
+        $expectedPIC = '39611300828';
+
+        $referenceInstitution = Institution::factory()->create(['name' => $expectedName]);
+        $referenceUser = User::factory()
+            ->create(['personal_identification_code' => $expectedPIC]);
+        $referenceRole = Role::factory()
+            ->for($referenceInstitution)
+            ->create(['name' => $expectedName]);
+        $referenceInstitutionUser = InstitutionUser::factory()
+            ->for($referenceInstitution)
+            ->for($referenceUser)
+            ->create();
+
+        $createdInstitutionUserRole = InstitutionUserRole::factory()
+            ->for($referenceInstitutionUser)
+            ->for($referenceRole)
+            ->create();
+
+        $this->assertModelExists($createdInstitutionUserRole->institutionUser);
+        $this->assertModelExists($createdInstitutionUserRole->role);
+        $this->assertModelExists($createdInstitutionUserRole->institutionUser->user);
+        $this->assertModelExists($createdInstitutionUserRole->institutionUser->institution);
+        $this->assertModelExists($createdInstitutionUserRole->role->institution);
+
+        $this->assertEquals($referenceInstitution->id, $createdInstitutionUserRole->institutionUser->institution->id);
+        $this->assertEquals($referenceInstitution->id, $createdInstitutionUserRole->role->institution->id);
+
+        $retrievedInstitution = Institution::findOrFail($createdInstitutionUserRole->role->institution->id);
+        $this->assertEquals($expectedName, $retrievedInstitution->name);
+
+        $retrievedRole = Role::findOrFail($createdInstitutionUserRole->role->id);
+        $this->assertEquals($expectedName, $retrievedRole->name);
+
+        $retrievedUser = User::findOrFail($createdInstitutionUserRole->institutionUser->user->id);
+        $this->assertModelExists($retrievedUser);
+        $this->assertEquals($expectedPIC, $retrievedUser->personal_identification_code);
+    }
+
+    public function test_duplicate_is_rejected(): void
+    {
+        $this->expectException(QueryException::class);
+
+        $referenceInstitutionUser = InstitutionUser::factory()->create();
+        $referenceRole = Role::factory()->create();
+
+        InstitutionUserRole::factory()
+            ->count(2)
+            ->for($referenceRole)
+            ->for($referenceInstitutionUser)
+            ->create();
+    }
+}

--- a/tests/Feature/Models/Database/InstitutionUserStatusTest.php
+++ b/tests/Feature/Models/Database/InstitutionUserStatusTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Feature\Models\Database;
+
+use App\Enum\InstitutionUserStatusKey;
+use App\Models\InstitutionUserStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Arr;
+use Tests\TestCase;
+
+class InstitutionUserStatusTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_institution_user_status_table_is_equal_to_enum(): void
+    {
+        $keysInDatabase = InstitutionUserStatus::all()
+            ->map(fn ($model) => $model->key->value)
+            ->toArray();
+
+        $keysInEnum = Arr::map(
+            InstitutionUserStatusKey::cases(),
+            fn ($enum) => $enum->value
+        );
+
+        $this->assertEmpty(array_diff($keysInDatabase, $keysInEnum)); // Check no keys missing in enum
+        $this->assertEmpty(array_diff($keysInEnum, $keysInDatabase)); // Check no keys missing in database
+    }
+}

--- a/tests/Feature/Models/Database/InstitutionUserTest.php
+++ b/tests/Feature/Models/Database/InstitutionUserTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Feature\Models\Database;
+
+use App\Enum\InstitutionUserStatusKey;
+use App\Models\Institution;
+use App\Models\InstitutionUser;
+use App\Models\InstitutionUserStatus;
+use App\Models\User;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class InstitutionUserTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_saving(): void
+    {
+        $createdModel = InstitutionUser::factory()->create();
+        $this->assertModelExists($createdModel);
+    }
+
+    public function test_institution_exists(): void
+    {
+        $expectedName = 'institution-user-test_test-institution-exists';
+
+        $createdRole = InstitutionUser::factory()->forInstitution(['name' => $expectedName])->create();
+        $this->assertModelExists($createdRole->institution);
+
+        $retrievedInstitution = Institution::findOrFail($createdRole->institution->id);
+        $this->assertEquals($expectedName, $retrievedInstitution->name);
+    }
+
+    public function test_user_exists(): void
+    {
+        $expectedPic = '39611300828';
+
+        $createdInstitutionUser = InstitutionUser::factory()->forUser(['personal_identification_code' => $expectedPic])->create();
+        $this->assertModelExists($createdInstitutionUser->user);
+
+        $retrievedUser = User::findOrFail($createdInstitutionUser->user->id);
+        $this->assertEquals($expectedPic, $retrievedUser->personal_identification_code);
+    }
+
+    public function test_status_exists(): void
+    {
+        $expectedKey = InstitutionUserStatusKey::Created->value;
+        $referenceStatus = InstitutionUserStatus::where('key', $expectedKey)->firstOrFail();
+
+        $createdInstitutionUser = InstitutionUser::factory()->for($referenceStatus)->create();
+        $this->assertModelExists($createdInstitutionUser->institutionUserStatus);
+
+        $retrievedStatus = InstitutionUserStatus::findOrFail($createdInstitutionUser->institutionUserStatus->id);
+        $this->assertEquals($expectedKey, $retrievedStatus->key->value);
+    }
+
+    public function test_duplicate_is_rejected(): void
+    {
+        $this->expectException(QueryException::class);
+
+        $referenceInstitution = Institution::factory()->create();
+        $referenceUser = User::factory()->create();
+
+        InstitutionUser::factory()
+            ->count(2)
+            ->for($referenceUser)
+            ->for($referenceInstitution)
+            ->create();
+    }
+}

--- a/tests/Feature/Models/Database/PrivilegeRoleTest.php
+++ b/tests/Feature/Models/Database/PrivilegeRoleTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Feature\Models\Database;
+
+use App\Enum\PrivilegeKey;
+use App\Models\Privilege;
+use App\Models\PrivilegeRole;
+use App\Models\Role;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PrivilegeRoleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_saving(): void
+    {
+        $createdModel = PrivilegeRole::factory()->create();
+        $this->assertModelExists($createdModel);
+    }
+
+    public function test_role_exists(): void
+    {
+        $expectedName = 'privilege-role-test_test-role-exists';
+
+        $createdPrivilegeRole = PrivilegeRole::factory()->forRole(['name' => $expectedName])->create();
+        $this->assertModelExists($createdPrivilegeRole->role);
+
+        $retrievedRole = Role::findOrFail($createdPrivilegeRole->role->id);
+        $this->assertEquals($expectedName, $retrievedRole->name);
+    }
+
+    public function test_privilege_exists(): void
+    {
+        $expectedKey = PrivilegeKey::AddUser->value;
+        $referencePrivilege = Privilege::where('key', $expectedKey)->firstOrFail();
+
+        $createdPrivilegeRole = PrivilegeRole::factory()->for($referencePrivilege)->create();
+        $this->assertModelExists($createdPrivilegeRole->privilege);
+
+        $retrievedPrivilege = Privilege::findOrFail($createdPrivilegeRole->privilege->id);
+        $this->assertEquals($expectedKey, $retrievedPrivilege->key->value);
+    }
+
+    public function test_duplicate_is_rejected(): void
+    {
+        $this->expectException(QueryException::class);
+
+        $referencePrivilege = Privilege::where('key', PrivilegeKey::AddUser->value)->firstOrFail();
+        $referenceRole = Role::factory()->create();
+
+        PrivilegeRole::factory()
+            ->count(2)
+            ->for($referencePrivilege)
+            ->for($referenceRole)
+            ->create();
+    }
+}

--- a/tests/Feature/Models/Database/PrivilegeTest.php
+++ b/tests/Feature/Models/Database/PrivilegeTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Feature\Models\Database;
+
+use App\Enum\PrivilegeKey;
+use App\Models\Privilege;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Arr;
+use Tests\TestCase;
+
+class PrivilegeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_privilege_table_is_equal_to_enum(): void
+    {
+        $keysInDatabase = Privilege::all()
+            ->map(fn ($model) => $model->key->value)
+            ->toArray();
+
+        $keysInEnum = Arr::map(
+            PrivilegeKey::cases(),
+            fn ($enum) => $enum->value
+        );
+
+        $this->assertEmpty(array_diff($keysInDatabase, $keysInEnum)); // Check no keys missing in enum
+        $this->assertEmpty(array_diff($keysInEnum, $keysInDatabase)); // Check no keys missing in database
+    }
+}

--- a/tests/Feature/Models/Database/RoleTest.php
+++ b/tests/Feature/Models/Database/RoleTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Feature\Models\Database;
+
+use App\Models\Institution;
+use App\Models\Role;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RoleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_saving(): void
+    {
+        $expected_name = 'role-test_test-saving';
+
+        $createdModel = Role::factory()->create(['name' => $expected_name]);
+        $this->assertModelExists($createdModel);
+
+        $retrievedModel = Role::findOrFail($createdModel->id);
+        $this->assertEquals($expected_name, $retrievedModel->name);
+    }
+
+    public function test_institution_exists(): void
+    {
+        $expected_name = 'role-test_test-institution-exists';
+
+        $createdRole = Role::factory()->forInstitution(['name' => $expected_name])->create();
+        $this->assertModelExists($createdRole->institution);
+
+        $retrievedInstitution = Institution::findOrFail($createdRole->institution->id);
+        $this->assertEquals($expected_name, $retrievedInstitution->name);
+    }
+}

--- a/tests/Feature/Models/Database/UserTest.php
+++ b/tests/Feature/Models/Database/UserTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Feature\Models\Database;
+
+use App\Models\User;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UserTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_saving(): void
+    {
+        $createdModel = User::factory()->create();
+        $this->assertModelExists($createdModel);
+
+        $retrievedModel = User::findOrFail($createdModel->id);
+        $this->assertEquals(
+            $createdModel->personal_identification_code,
+            $retrievedModel->personal_identification_code
+        );
+    }
+
+    public function test_duplicate_pic_fails(): void
+    {
+        $this->expectException(QueryException::class);
+
+        User::factory()
+            ->count(2)
+            ->create(['personal_identification_code' => '39611300828']);
+    }
+}


### PR DESCRIPTION
Part of https://github.com/keeleinstituut/tv-tolkevarav/issues/78.

* Created database migrations
* Created data model with Eloquent ORM
* Created tests for testing data model and migration scripts.

Note: For pivot table models (used for many-to-many relationships), I chose not to inherit `\Illuminate\Database\Eloquent\Relations\Pivot` because it does [not support automatic soft deletion](https://laravel.com/docs/10.x/eloquent-relationships#defining-custom-intermediate-table-models). So I chose to inherit `Model` instead.

Please let me know if you have any questions; I’m happy to discuss.