### PR TITLE
Refactor: Add PhpDoc tag comments for magic properties of model classes

### DIFF
--- a/app/Models/Institution.php
+++ b/app/Models/Institution.php
@@ -2,12 +2,23 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 
+/**
+ * @property string $id
+ * @property Carbon $deleted_at
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ * @property string $name
+ * @property Collection<InstitutionUser> $institutionUsers
+ * @property Collection<Role> $roles
+ */
 class Institution extends Model
 {
     use HasFactory, SoftDeletes, HasUuids;

--- a/app/Models/InstitutionUser.php
+++ b/app/Models/InstitutionUser.php
@@ -3,13 +3,25 @@
 namespace App\Models;
 
 use App\Enum\InstitutionUserStatus;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 
+/**
+ * @property string $id
+ * @property Carbon $deleted_at
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ * @property Institution $institution
+ * @property InstitutionUserStatus $status
+ * @property User $user
+ * @property Collection<InstitutionUserRole> $institutionUserRoles
+ */
 class InstitutionUser extends Model
 {
     use HasFactory, SoftDeletes, HasUuids;

--- a/app/Models/InstitutionUserRole.php
+++ b/app/Models/InstitutionUserRole.php
@@ -7,7 +7,16 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 
+/**
+ * @property string $id
+ * @property Carbon $deleted_at
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ * @property Role $role
+ * @property InstitutionUser $institutionUser
+ */
 class InstitutionUserRole extends Model
 {
     use HasFactory, SoftDeletes, HasUuids;

--- a/app/Models/Privilege.php
+++ b/app/Models/Privilege.php
@@ -3,14 +3,26 @@
 namespace App\Models;
 
 use App\Enum\PrivilegeKey;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 
+/**
+ * @property string $id
+ * @property Carbon $deleted_at
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ * @property PrivilegeKey $key
+ * @property string $description
+ * @property Collection<PrivilegeRole> $privilegeRoles
+ */
 class Privilege extends Model
 {
-    use HasFactory, HasUuids;
+    use HasFactory, HasUuids, SoftDeletes;
 
     /**
      * The attributes that are mass assignable.
@@ -28,7 +40,7 @@ class Privilege extends Model
         'key' => PrivilegeKey::class,
     ];
 
-    public function rolePrivileges(): HasMany
+    public function privilegeRoles(): HasMany
     {
         return $this->hasMany(PrivilegeRole::class);
     }

--- a/app/Models/PrivilegeRole.php
+++ b/app/Models/PrivilegeRole.php
@@ -7,7 +7,16 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 
+/**
+ * @property string $id
+ * @property Carbon $deleted_at
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ * @property Privilege $privilege
+ * @property Role $role
+ */
 class PrivilegeRole extends Model
 {
     use HasFactory, SoftDeletes, HasUuids;

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -2,13 +2,25 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 
+/**
+ * @property string $id
+ * @property Carbon $deleted_at
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ * @property string $name
+ * @property Institution $institution
+ * @property Collection<PrivilegeRole> $privilegeRoles
+ * @property Collection<InstitutionUserRole> $institutionUserRoles
+ */
 class Role extends Model
 {
     use HasFactory, SoftDeletes, HasUuids;
@@ -18,7 +30,7 @@ class Role extends Model
         return $this->hasMany(InstitutionUserRole::class);
     }
 
-    public function rolePrivileges(): HasMany
+    public function privilegeRoles(): HasMany
     {
         return $this->hasMany(PrivilegeRole::class);
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,12 +2,24 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Support\Carbon;
 
+/**
+ * @property string $id
+ * @property Carbon $deleted_at
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ * @property string $forename
+ * @property string $surname
+ * @property string $personal_identification_code
+ * @property Collection<InstitutionUser> $institutionUsers
+ */
 class User extends Authenticatable
 {
     use HasFactory, SoftDeletes, HasUuids;


### PR DESCRIPTION
No functional changes – only refactoring in this PR.

I added [PHPDoc tag comments](https://docs.phpdoc.org/guide/getting-started/what-is-a-docblock.html#what-is-a-docblock) to class definitions which helps IDEs (e.g. PhpStorm) autocomplete properties. This does not seem to happen by default on "magic properties" such as the ones used by Eloquent models.