### PR TITLE
#111: Create endpoint for fetching current user institutions

### DIFF
--- a/application/app/Http/Controllers/InstitutionController.php
+++ b/application/app/Http/Controllers/InstitutionController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Resources\InstitutionResource;
+use App\Models\Institution;
+use Illuminate\Http\Resources\Json\ResourceCollection;
+use Illuminate\Support\Facades\Auth;
+
+class InstitutionController extends Controller
+{
+    public function index(): ResourceCollection
+    {
+        $personalIdentificationCode = Auth::user()?->personalIdentificationCode;
+
+        abort_if(empty($personalIdentificationCode), 401);
+
+        return InstitutionResource::collection(
+            Institution::queryByUserPersonalIdentificationCode($personalIdentificationCode)->get()
+        );
+    }
+}

--- a/application/app/Http/Resources/InstitutionResource.php
+++ b/application/app/Http/Resources/InstitutionResource.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Models\Institution;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin Institution
+ */
+class InstitutionResource extends JsonResource
+{
+    /**
+     * @return array{
+     *     id: string,
+     *     name: string,
+     *     phone: string,
+     *     email: string,
+     *     short_name: string,
+     *     logo_url: string,
+     *     updated_at: Carbon,
+     *     created_at: Carbon
+     * }
+     */
+    public function toArray(Request $request): array
+    {
+        return $this->only(
+            'id',
+            'name',
+            'short_name',
+            'phone',
+            'email',
+            'logo_url',
+            'created_at',
+            'updated_at',
+        );
+    }
+}

--- a/application/app/Models/Institution.php
+++ b/application/app/Models/Institution.php
@@ -17,6 +17,9 @@ use Illuminate\Support\Carbon;
  * App\Models\Institution
  *
  * @property string $id
+ * @property string|null $short_name
+ * @property string|null $email
+ * @property string|null $phone
  * @property Carbon|null $deleted_at
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
@@ -35,6 +38,10 @@ use Illuminate\Support\Carbon;
  * @method static Builder|Institution whereCreatedAt($value)
  * @method static Builder|Institution whereDeletedAt($value)
  * @method static Builder|Institution whereId($value)
+ * @method static Builder|Institution whereShortName($value)
+ * @method static Builder|Institution whereLogoUrl($value)
+ * @method static Builder|Institution whereEmail($value)
+ * @method static Builder|Institution wherePhone($value)
  * @method static Builder|Institution whereName($value)
  * @method static Builder|Institution whereUpdatedAt($value)
  * @method static Builder|Institution withTrashed()
@@ -46,7 +53,7 @@ class Institution extends Model
 {
     use HasFactory, SoftDeletes, HasUuids;
 
-    protected $fillable = ['name', 'logo_url'];
+    protected $fillable = ['name', 'logo_url', 'short_name', 'email', 'phone'];
 
     public function institutionUsers(): HasMany
     {
@@ -56,5 +63,19 @@ class Institution extends Model
     public function roles(): HasMany
     {
         return $this->hasMany(Role::class);
+    }
+
+    public static function queryByUserPersonalIdentificationCode(string $personalIdentificationCode): Builder
+    {
+        return static::whereHas(
+            'institutionUsers',
+            fn (Builder $institutionUserQuery) => $institutionUserQuery->whereHas(
+                'user',
+                fn (Builder $userQuery) => $userQuery->where(
+                    'personal_identification_code',
+                    $personalIdentificationCode
+                )
+            )
+        );
     }
 }

--- a/application/database/factories/InstitutionFactory.php
+++ b/application/database/factories/InstitutionFactory.php
@@ -19,6 +19,10 @@ class InstitutionFactory extends Factory
     {
         return [
             'name' => fake()->company(),
+            'short_name' => null,
+            'phone' => null,
+            'email' => fake()->companyEmail(),
+            'logo_url' => fake()->url(),
         ];
     }
 }

--- a/application/database/migrations/2023_05_09_085510_add_institution_contacts_columns.php
+++ b/application/database/migrations/2023_05_09_085510_add_institution_contacts_columns.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('institutions', function (Blueprint $table) {
+            $table->string('short_name', 3)->nullable();
+            $table->string('email', 50)->nullable();
+            $table->string('phone', 50)->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('institutions', function (Blueprint $table) {
+            $table->dropColumn(['short_name', 'email', 'phone']);
+        });
+    }
+};

--- a/application/routes/api.php
+++ b/application/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\API\PrivilegeController;
 use App\Http\Controllers\API\RoleController;
+use App\Http\Controllers\InstitutionController;
 use App\Http\Controllers\JwtClaimsController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -28,4 +29,7 @@ Route::post('/roles', [RoleController::class, 'store']);
 Route::get('/roles/{role_id}', [RoleController::class, 'show'])->whereUuid('role_id');
 Route::put('/roles/{role_id}', [RoleController::class, 'update'])->whereUuid('role_id');
 Route::delete('/roles/{role_id}', [RoleController::class, 'destroy'])->whereUuid('role_id');
+
 Route::get('/jwt-claims', [JwtClaimsController::class, 'show'])->withoutMiddleware('auth:api');
+
+Route::get('/institutions', [InstitutionController::class, 'index']);

--- a/application/tests/Feature/Http/Controllers/InstitutionControllerTest.php
+++ b/application/tests/Feature/Http/Controllers/InstitutionControllerTest.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use App\Models\Institution;
+use App\Models\InstitutionUser;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Testing\TestResponse;
+use Tests\Feature\RepresentationHelpers;
+use Tests\TestCase;
+
+class InstitutionControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function setUp(): void
+    {
+        parent::setup();
+        Carbon::setTestNow(Carbon::now());
+    }
+
+    public function test_correct_data_is_returned(): void
+    {
+        // GIVEN there’s a user connected to two institutions in the database
+        InstitutionUser::factory()
+            ->for($expectedInstitution1 = Institution::factory()->create())
+            ->for($user = User::factory()->create([
+                'personal_identification_code' => $personalIdentificationCode = '50511246084',
+            ]))
+            ->create();
+        InstitutionUser::factory()
+            ->for($expectedInstitution2 = Institution::factory()->create())
+            ->for($user)
+            ->create();
+
+        // WHEN request sent to endpoint
+        $response = $this->sendGetRequest($personalIdentificationCode);
+
+        // THEN request response should only contain the institutions expected
+        $response
+            ->assertStatus(200)
+            ->assertJsonFragment([
+                'data' => [
+                    RepresentationHelpers::createInstitutionFlatRepresentation($expectedInstitution1),
+                    RepresentationHelpers::createInstitutionFlatRepresentation($expectedInstitution2),
+                ],
+            ]);
+    }
+
+    public function test_soft_deleted_institution_is_excluded(): void
+    {
+        // GIVEN there’s a user connected to two institutions in the database, one of which has been soft deleted
+        InstitutionUser::factory()
+            ->for($expectedInstitution = Institution::factory()->create())
+            ->for($user = User::factory()->create([
+                'personal_identification_code' => $personalIdentificationCode = '50511246084',
+            ]))
+            ->create();
+        InstitutionUser::factory()
+            ->for($softDeletedInstitution = Institution::factory()->create())
+            ->for($user)
+            ->create();
+
+        $softDeletedInstitution->delete();
+
+        // WHEN request sent to endpoint
+        $response = $this->sendGetRequest($personalIdentificationCode);
+
+        // THEN request response should only contain the institution that wasn't soft deleted
+        $response
+            ->assertStatus(200)
+            ->assertJsonFragment([
+                'data' => [RepresentationHelpers::createInstitutionFlatRepresentation($expectedInstitution)],
+            ]);
+    }
+
+    public function test_soft_deleted_institution_user_is_excluded(): void
+    {
+        // GIVEN there’s a user connected to two institutions in the database, with one for the pivots having been soft deleted
+        InstitutionUser::factory()
+            ->for($expectedInstitution = Institution::factory()->create())
+            ->for($user = User::factory()->create([
+                'personal_identification_code' => $personalIdentificationCode = '50511246084',
+            ]))
+            ->create();
+        InstitutionUser::factory()
+            ->for(Institution::factory()->create())
+            ->for($user)
+            ->create()
+            ->delete();
+
+        // WHEN request sent to endpoint
+        $response = $this->sendGetRequest($personalIdentificationCode);
+
+        // THEN request response should only contain the institution for which the pivot wasn't soft deleted
+        $response
+            ->assertStatus(200)
+            ->assertJsonFragment([
+                'data' => [RepresentationHelpers::createInstitutionFlatRepresentation($expectedInstitution)],
+            ]);
+    }
+
+    public function test_soft_deleted_user_is_excluded(): void
+    {
+        // GIVEN there’s a user connected to an institution in the database, but the user has been soft deleted
+        InstitutionUser::factory()
+            ->for(Institution::factory()->create())
+            ->for($user = User::factory()->create([
+                'personal_identification_code' => $personalIdentificationCode = '50511246084',
+            ]))
+            ->create();
+        $user->delete();
+
+        // WHEN request sent to endpoint
+        $response = $this->sendGetRequest($personalIdentificationCode);
+
+        // THEN response data should be empty
+        $response
+            ->assertStatus(200)
+            ->assertJsonPath('data', []);
+    }
+
+    public function test_requesting_nonexistent_user(): void
+    {
+        // GIVEN the following data is in database
+        InstitutionUser::factory()
+            ->for(Institution::factory()->create())
+            ->for(User::factory()->create([
+                'personal_identification_code' => '60810202280',
+            ]))->create();
+
+        // WHEN request targets nonexistent institution user
+        $response = $this->sendGetRequest('32402126598');
+
+        // THEN response data should be empty
+        $response
+            ->assertStatus(200)
+            ->assertJsonPath('data', []);
+    }
+
+    public function test_updating_user_without_access_token(): void
+    {
+        // GIVEN the following data is in database
+        InstitutionUser::factory()
+            ->for(Institution::factory()->create())
+            ->for(User::factory()->create([
+                'personal_identification_code' => '50511246084',
+            ]))->create();
+
+        // WHEN request sent without access token in header
+        $response = $this
+            ->withHeaders(['Accept' => 'application/json'])
+            ->getJson('/api/institutions');
+
+        // THEN response should indicate that the request failed authentication
+        $response->assertUnauthorized();
+    }
+
+    public function test_updating_user_when_pic_missing_in_access_token(): void
+    {
+        // GIVEN the following data is in database
+        InstitutionUser::factory()
+            ->for(Institution::factory()->create())
+            ->for(User::factory()->create([
+                'personal_identification_code' => '50511246084',
+            ]))->create();
+
+        // WHEN request sent without PIC in access token
+        $response = $this->sendGetRequest(null);
+
+        // THEN response should indicate that the request failed authentication
+        $response->assertUnauthorized();
+    }
+
+    private function sendGetRequest(?string $tokenPersonalIdentificationCode): TestResponse
+    {
+        $accessToken = $this->generateAccessToken([
+            'personalIdentificationCode' => $tokenPersonalIdentificationCode,
+        ]);
+
+        return $this
+            ->withHeaders([
+                'Authorization' => "Bearer $accessToken",
+                'Accept' => 'application/json',
+            ])
+            ->getJson('/api/institutions');
+    }
+}

--- a/application/tests/Feature/RepresentationHelpers.php
+++ b/application/tests/Feature/RepresentationHelpers.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Institution;
+use Illuminate\Support\Arr;
+
+class RepresentationHelpers
+{
+    public static function createInstitutionFlatRepresentation(Institution $institution): array
+    {
+        return Arr::only($institution->toArray(), [
+            'id',
+            'name',
+            'logo_url',
+            'updated_at',
+            'created_at',
+            'short_name',
+            'phone',
+            'email',
+        ]);
+    }
+}


### PR DESCRIPTION
Resolves issue: https://github.com/keeleinstituut/tv-tolkevarav/issues/111

* Added some columns to institutions table
* Added institutions "index" endpoint which returns institutions of authenticated user

----

Note that this endpoint does not assume that there’s anything other than `personalIdentificationCode` in the JWT. This is because this endpoint is used before an institution has been selected. 