### PR TITLE
Hotfix: rename privileges of worktime and vacation

### DIFF
--- a/application/app/Enums/DefaultRole.php
+++ b/application/app/Enums/DefaultRole.php
@@ -21,8 +21,8 @@ enum DefaultRole: string
                 PrivilegeKey::ActivateUser,
                 PrivilegeKey::DeactivateUser,
                 PrivilegeKey::ArchiveUser,
-                PrivilegeKey::SetUserWorkTime,
-                PrivilegeKey::SetUserVacation,
+                PrivilegeKey::EditUserWorkTime,
+                PrivilegeKey::EditUserVacation,
             ],
             default => []
         };

--- a/application/app/Enums/PrivilegeKey.php
+++ b/application/app/Enums/PrivilegeKey.php
@@ -15,6 +15,6 @@ enum PrivilegeKey: string
     case ActivateUser = 'ACTIVATE_USER';
     case DeactivateUser = 'DEACTIVATE_USER';
     case ArchiveUser = 'ARCHIVE_USER';
-    case SetUserWorkTime = 'SET_USER_WORKTIME';
-    case SetUserVacation = 'SET_USER_VACATION';
+    case EditUserWorkTime = 'EDIT_USER_WORKTIME';
+    case EditUserVacation = 'EDIT_USER_VACATION';
 }

--- a/application/database/migrations/2023_05_24_134631_rename_privileges_of_worktime_and_vacation.php
+++ b/application/database/migrations/2023_05_24_134631_rename_privileges_of_worktime_and_vacation.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('privileges', function (Blueprint $table) {
+            DB::table($table->getTable())
+                ->where(['key' => 'SET_USER_WORKTIME'])
+                ->update(['key' => 'EDIT_USER_WORKTIME']);
+
+            DB::table($table->getTable())
+                ->where(['key' => 'SET_USER_VACATION'])
+                ->update(['key' => 'EDIT_USER_VACATION']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('privileges', function (Blueprint $table) {
+            DB::table($table->getTable())
+                ->where(['key' => 'EDIT_USER_WORKTIME'])
+                ->update(['key' => 'SET_USER_WORKTIME']);
+
+            DB::table($table->getTable())
+                ->where(['key' => 'EDIT_USER_VACATION'])
+                ->update(['key' => 'SET_USER_VACATION']);
+        });
+    }
+};

--- a/application/tests/Feature/Http/Controllers/InstitutionUserControllerShowTest.php
+++ b/application/tests/Feature/Http/Controllers/InstitutionUserControllerShowTest.php
@@ -157,7 +157,7 @@ class InstitutionUserControllerShowTest extends TestCase
         $response = $this->sendGetRequest(
             $createdInstitutionUser->id,
             $createdInstitution->id,
-            [PrivilegeKey::SetUserVacation]
+            [PrivilegeKey::EditUserVacation]
         );
 
         // THEN response should indicate action is forbidden

--- a/application/tests/Feature/Models/Database/PrivilegeTest.php
+++ b/application/tests/Feature/Models/Database/PrivilegeTest.php
@@ -8,7 +8,7 @@ use App\Models\Privilege;
 use App\Models\PrivilegeRole;
 use App\Models\Role;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 class PrivilegeTest extends TestCase
@@ -17,17 +17,17 @@ class PrivilegeTest extends TestCase
 
     public function test_privilege_table_is_equal_to_enum(): void
     {
-        $keysInDatabase = Privilege::all()
-            ->map(fn ($model) => $model->key->value)
+        $keysInDatabase = DB::table('privileges')
+            ->pluck('key')
+            ->sort()
             ->toArray();
 
-        $keysInEnum = Arr::map(
-            PrivilegeKey::cases(),
-            fn ($enum) => $enum->value
-        );
+        $keysInEnum = collect(PrivilegeKey::cases())
+            ->map(fn (PrivilegeKey $enum) => $enum->value)
+            ->sort()
+            ->toArray();
 
-        $this->assertEmpty(array_diff($keysInDatabase, $keysInEnum)); // Check no keys missing in enum
-        $this->assertEmpty(array_diff($keysInEnum, $keysInDatabase)); // Check no keys missing in database
+        $this->assertEquals($keysInEnum, $keysInDatabase);
     }
 
     public function test_adding_role_pivots(): void


### PR DESCRIPTION
Renamed privileges as requested by teammates:
* `SET_USER_WORKTIME`  ->  `EDIT_USER_WORKTIME`
* `SET_USER_VACATION` ->  `EDIT_USER_VACATION`
