### PR TITLE
Update .env.example so tests will not fail using it

### DIFF
--- a/application/.env.example
+++ b/application/.env.example
@@ -13,14 +13,14 @@ LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug
 
 DB_CONNECTION=pgsql
-DB_HOST=localhost
+DB_HOST=postgres
 # Should be the same as ../.env DB_PORT
-DB_PORT=5434
+DB_PORT=5432
 DB_DATABASE=app
 DB_USERNAME=user
 DB_PASSWORD=pass
 
-AMQP_HOST=localhost
+AMQP_HOST=rabbitmq
 # Should be the same as ../.env AMQP_PORT
 AMQP_PORT=5672
 AMQP_USER=guest


### PR DESCRIPTION
Due to port mismatches in `.env.example`, some tests were failing with those values.  

Ideally all tests pass would pass with either of these two approaches:

```sh
# Run tests within the docker image
cp .env.example .env \
  && cp application/.env.example application/.env \
  && docker compose run --build app sh -c 'php artisan migrate:fresh && php artisan test'
```

```sh
# Start docker compose services (Postgres, RabbitMQ etc) in the background
cp .env.example .env \
  && cp application/.env.example application/.env \
  && docker compose up --wait --build --force-recreate 

# Run tests in your own environment 
php application/artisan migrate:fresh \
  && (cd application && php artisan test)
```

Assuming your `/etc/hosts` has `postgres` and `rabbitmq` pointing to localhost, then with these changes both commands should work.

P.S. @thenouan has indicated that the first option is preferrable for running tests.