### PR TITLE
Fix flaky tests

### DIFF
--- a/application/tests/Feature/Http/Controllers/InstitutionUserControllerShowTest.php
+++ b/application/tests/Feature/Http/Controllers/InstitutionUserControllerShowTest.php
@@ -68,7 +68,7 @@ class InstitutionUserControllerShowTest extends TestCase
                 'personal_identification_code' => $expectedPic,
             ],
         ];
-        $this->assertResponseJsonDataIsEqualTo($expectedResponseData, $response);
+        $this->assertResponseJsonDataEqualsIgnoringOrder($expectedResponseData, $response);
     }
 
     public function test_requesting_nonexistent_user(): void

--- a/application/tests/Feature/Http/Controllers/InstitutionUserControllerUpdateTest.php
+++ b/application/tests/Feature/Http/Controllers/InstitutionUserControllerUpdateTest.php
@@ -83,10 +83,10 @@ class InstitutionUserControllerUpdateTest extends TestCase
                 'surname' => $expectedSurname,
             ],
         ];
-        $this->assertArrayHasSpecifiedFragment($expectedFragment, $actualState);
+        $this->assertArrayHasSpecifiedFragmentIgnoringOrder($expectedFragment, $actualState);
 
         // And request response should correspond to the actual state
-        $this->assertResponseJsonDataIsEqualTo($actualState, $response);
+        $this->assertResponseJsonDataEqualsIgnoringOrder($actualState, $response);
     }
 
     /**
@@ -114,10 +114,10 @@ class InstitutionUserControllerUpdateTest extends TestCase
         $actualState = RepresentationHelpers::createInstitutionUserNestedRepresentation(
             InstitutionUser::findOrFail($createdInstitutionUser->id)
         );
-        $this->assertArrayHasSpecifiedFragment(['roles' => []], $actualState);
+        $this->assertArrayHasSpecifiedFragmentIgnoringOrder(['roles' => []], $actualState);
 
         // And request response should correspond to the actual state
-        $this->assertResponseJsonDataIsEqualTo($actualState, $response);
+        $this->assertResponseJsonDataEqualsIgnoringOrder($actualState, $response);
     }
 
     /**
@@ -143,10 +143,10 @@ class InstitutionUserControllerUpdateTest extends TestCase
         $actualState = RepresentationHelpers::createInstitutionUserNestedRepresentation(
             InstitutionUser::findOrFail($createdInstitutionUser->id)
         );
-        $this->assertArrayHasSpecifiedFragment(['department' => null], $actualState);
+        $this->assertArrayHasSpecifiedFragmentIgnoringOrder(['department' => null], $actualState);
 
         // And request response should correspond to the actual state
-        $this->assertResponseJsonDataIsEqualTo($actualState, $response);
+        $this->assertResponseJsonDataEqualsIgnoringOrder($actualState, $response);
     }
 
     /**
@@ -212,10 +212,10 @@ class InstitutionUserControllerUpdateTest extends TestCase
         $actualState = RepresentationHelpers::createInstitutionUserNestedRepresentation(
             InstitutionUser::findOrFail($createdInstitutionUser->id)
         );
-        $this->assertArrayHasSpecifiedFragment(['phone' => $validPhoneNumber], $actualState);
+        $this->assertArrayHasSpecifiedFragmentIgnoringOrder(['phone' => $validPhoneNumber], $actualState);
 
         // And request response should correspond to the actual state
-        $this->assertResponseJsonDataIsEqualTo($actualState, $response);
+        $this->assertResponseJsonDataEqualsIgnoringOrder($actualState, $response);
     }
 
     public function test_updating_nonexistent_user(): void

--- a/application/tests/Feature/ModelAssertions.php
+++ b/application/tests/Feature/ModelAssertions.php
@@ -88,7 +88,7 @@ trait ModelAssertions
                 ->all()
             : $convertModelToArray($expectedResponse->refresh());
 
-        $testResponse->assertJsonFragment(['data' => $expectedResponseData]);
+        $this->assertResponseJsonDataEqualsIgnoringOrder($expectedResponseData, $testResponse);
     }
 
     /**
@@ -134,7 +134,7 @@ trait ModelAssertions
             ->mapSpread(fn (Model $model) => $convertModelToArray($model->refresh()))
             ->all();
 
-        $this->assertEqualAsJsonIgnoringOrderRecursively($expectedStateAfterAction, $actualStateAfterAction);
+        $this->assertEqualAsJsonIgnoringOrder($expectedStateAfterAction, $actualStateAfterAction);
         $response->assertStatus($expectedStatus);
 
         return $response;

--- a/application/tests/TestCase.php
+++ b/application/tests/TestCase.php
@@ -11,20 +11,22 @@ abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
 
-    public function assertResponseJsonDataIsEqualTo(array $expectedData, TestResponse $actualResponse): void
+    public function assertResponseJsonDataEqualsIgnoringOrder(array $expectedData, TestResponse $actualResponse): void
     {
-        $actualResponse
-            ->assertStatus(200)
-            ->assertExactJson(['data' => $expectedData]);
+        $this->assertEqualAsJsonIgnoringOrder($expectedData, $actualResponse->json('data'));
     }
 
-    public function assertArrayHasSpecifiedFragment(array $expectedFragment, array $actual): void
+    public function assertArrayHasSpecifiedFragmentIgnoringOrder(array $expectedFragment, array $actual): void
     {
         $actualFragment = Arr::only($actual, array_keys($expectedFragment));
-        $this->assertEquals($expectedFragment, $actualFragment);
+
+        $this->assertEquals(
+            Arr::sortRecursive($expectedFragment),
+            Arr::sortRecursive($actualFragment)
+        );
     }
 
-    public function assertEqualAsJsonIgnoringOrderRecursively(array $expected, array $actual): void
+    public function assertEqualAsJsonIgnoringOrder(array $expected, array $actual): void
     {
         $assertableJsonString = new AssertableJsonString($actual);
         $assertableJsonString->assertSimilar($expected);


### PR DESCRIPTION
There are some flaky tests which fail because some resource is sometimes returned in a different order, even when checking order is not important for business logic. I’ve lost a non-trivial amount of time having to re-run tests.

I fixed it with by using the correct assertion methods and sorting arrays recursively when needed. Most of the work was done by my IDE.