### PR TITLE
FIX: Replace HasMany mass-deletion with iteratively deleting Models

### DIFF
--- a/application/app/Http/Controllers/InstitutionUserController.php
+++ b/application/app/Http/Controllers/InstitutionUserController.php
@@ -12,6 +12,7 @@ use App\Http\Requests\InstitutionUserListRequest;
 use App\Http\Requests\UpdateInstitutionUserRequest;
 use App\Http\Resources\InstitutionUserResource;
 use App\Models\InstitutionUser;
+use App\Models\InstitutionUserRole;
 use App\Models\Role;
 use App\Models\Scopes\ExcludeArchivedInstitutionUsersScope;
 use App\Models\Scopes\ExcludeDeactivatedInstitutionUsersScope;
@@ -249,7 +250,7 @@ class InstitutionUserController extends Controller
             $institutionUser->saveOrFail();
 
             if ($request->getValidatedDeactivationDateAtEstonianMidnight()?->isSameDay(Date::today(DateUtil::ESTONIAN_TIMEZONE))) {
-                $institutionUser->institutionUserRoles()->delete();
+                $institutionUser->institutionUserRoles()->each(fn (InstitutionUserRole $pivot) => $pivot->deleteOrFail());
             }
 
             // TODO: audit log
@@ -310,7 +311,7 @@ class InstitutionUserController extends Controller
             $this->authorize('archive', $institutionUser);
 
             $institutionUser->archived_at = Date::now();
-            $institutionUser->institutionUserRoles()->delete();
+            $institutionUser->institutionUserRoles()->each(fn (InstitutionUserRole $pivot) => $pivot->deleteOrFail());
             $institutionUser->saveOrFail();
 
             // TODO: audit log

--- a/application/app/Observers/RoleObserver.php
+++ b/application/app/Observers/RoleObserver.php
@@ -4,6 +4,7 @@ namespace App\Observers;
 
 use App\Events\Publishers\InstitutionUserEventsPublisher;
 use App\Exceptions\DeniedRootRoleModifyException;
+use App\Models\PrivilegeRole;
 use App\Models\Role;
 
 readonly class RoleObserver
@@ -59,7 +60,7 @@ readonly class RoleObserver
      */
     public function deleted(Role $role): void
     {
-        $role->privilegeRoles()->delete();
+        $role->privilegeRoles()->each(fn (PrivilegeRole $pivot) => $pivot->deleteOrFail());
         $this->publishAffectedInstitutionUsers($role);
     }
 

--- a/application/tests/Feature/Http/Controllers/DepartmentControllerDestroyTest.php
+++ b/application/tests/Feature/Http/Controllers/DepartmentControllerDestroyTest.php
@@ -30,7 +30,7 @@ class DepartmentControllerDestroyTest extends DepartmentControllerTestCase
                     ->create();
             }],
             'Department without members' => [function (Department $department) {
-                $department->institutionUsers()->delete();
+                $department->institutionUsers()->each(fn (InstitutionUser $institutionUser) => $institutionUser->deleteOrFail());
             }],
         ];
     }

--- a/application/tests/Feature/Http/Controllers/DepartmentControllerIndexTest.php
+++ b/application/tests/Feature/Http/Controllers/DepartmentControllerIndexTest.php
@@ -43,7 +43,7 @@ class DepartmentControllerIndexTest extends DepartmentControllerTestCase
                 1,
             ],
             'Second department has no members' => [
-                [null, fn (Department $department) => $department->institutionUsers()->delete()],
+                [null, fn (Department $department) => $department->institutionUsers()->each(fn (InstitutionUser $institutionUser) => $institutionUser->deleteOrFail())],
                 null,
             ],
         ];

--- a/application/tests/Feature/Http/Controllers/DepartmentControllerShowTest.php
+++ b/application/tests/Feature/Http/Controllers/DepartmentControllerShowTest.php
@@ -27,7 +27,7 @@ class DepartmentControllerShowTest extends DepartmentControllerTestCase
                 Response::HTTP_OK,
             ],
             'Department without members' => [
-                fn (Department $department) => $department->institutionUsers()->delete(),
+                fn (Department $department) => $department->institutionUsers()->each(fn (InstitutionUser $institutionUser) => $institutionUser->deleteOrFail()),
                 Response::HTTP_OK,
             ],
             'Department soft-deleted' => [


### PR DESCRIPTION
This was causing an issue in which the expected events were not being triggered.