### PR TITLE
Fix: Use nullsafe operator when accessing relations in observers

### DIFF
--- a/application/app/Observers/InstitutionUserRoleObserver.php
+++ b/application/app/Observers/InstitutionUserRoleObserver.php
@@ -30,7 +30,7 @@ readonly class InstitutionUserRoleObserver
     {
         if ($institutionUserRole->isDirty('role_id')) {
             $originalRole = Role::findOrFail($institutionUserRole->getOriginal('role_id'));
-            if ($originalRole->is_root && $institutionUserRole->institutionUser->isOnlyUserWithRootRole()) {
+            if ($originalRole->is_root && $institutionUserRole->institutionUser?->isOnlyUserWithRootRole()) {
                 throw new OnlyUserUnderRootRoleException();
             }
         }
@@ -51,7 +51,7 @@ readonly class InstitutionUserRoleObserver
      */
     public function deleting(InstitutionUserRole $institutionUserRole): void
     {
-        if ($institutionUserRole->role->is_root && $institutionUserRole->institutionUser->isOnlyUserWithRootRole()) {
+        if ($institutionUserRole->role?->is_root && $institutionUserRole->institutionUser?->isOnlyUserWithRootRole()) {
             throw new OnlyUserUnderRootRoleException();
         }
     }

--- a/application/app/Observers/PrivilegeRoleObserver.php
+++ b/application/app/Observers/PrivilegeRoleObserver.php
@@ -36,7 +36,7 @@ readonly class PrivilegeRoleObserver
                 $roleToCheck = $privilegeRole->role;
             }
 
-            if ($roleToCheck->is_root) {
+            if ($roleToCheck?->is_root) {
                 throw new DeniedRootRoleModifyException();
             }
         }
@@ -57,7 +57,7 @@ readonly class PrivilegeRoleObserver
      */
     public function deleting(PrivilegeRole $privilegeRole): void
     {
-        if ($privilegeRole->role->is_root) {
+        if ($privilegeRole->role?->is_root) {
             throw new DeniedRootRoleModifyException();
         }
     }
@@ -86,7 +86,9 @@ readonly class PrivilegeRoleObserver
 
     private function publishAffectedInstitutionUsers(PrivilegeRole $privilegeRole): void
     {
-        $privilegeRole->role->institutionUserRoles()->pluck('institution_user_id')
+        $privilegeRole->role()
+            ->getRelation('institutionUserRoles')
+            ->pluck('institution_user_id')
             ->each(fn (string $institutionUserId) => $this->publisher->publishSyncEvent($institutionUserId));
     }
 }


### PR DESCRIPTION
If the relation has been soft-deleted, then the relation will evaluate to null. This was resulting in a runtime error.

I noticed that some tests were failing in the main branch after my changes in https://github.com/keeleinstituut/tv-authorization/pull/55. This PR fixes that. No idea how I missed that – I usually always run tests before publishing a PR.