### PR TITLE
fix(#212): check EDIT_INSTITUTION_WORKTIME privilege instead of EDIT_INSTITUTION when only editing institution worktimes

### DIFF
--- a/application/app/Http/Controllers/InstitutionController.php
+++ b/application/app/Http/Controllers/InstitutionController.php
@@ -61,12 +61,20 @@ class InstitutionController extends Controller
     #[OAH\ResourceResponse(dataRef: InstitutionResource::class, description: 'Modified institution')]
     public function update(UpdateInstitutionRequest $request): InstitutionResource
     {
-        $id = $request->route('institution_id');
-        $institution = $this->getBaseQuery()->findOrFail($id);
+        $institution = $this->getBaseQuery()->findOrFail($request->route('institution_id'));
 
-        $this->authorize('update', $institution);
+        if ($request->hasAnyNonCalendarInput()) {
+            $this->authorize('update', $institution);
+            $institution->fill($request->getValidatedNonCalendarInput());
+        }
 
-        $institution->fill($request->validated())->saveOrFail();
+        if ($request->hasAnyWorktimeInput()) {
+            $this->authorize('updateWorktime', $institution);
+            $institution->fill($request->getValidatedWorktimeInput());
+        }
+
+        $institution->saveOrFail();
+        // TODO: audit log
 
         return new InstitutionResource($institution->refresh());
     }

--- a/application/app/Http/Requests/UpdateInstitutionRequest.php
+++ b/application/app/Http/Requests/UpdateInstitutionRequest.php
@@ -100,6 +100,31 @@ class UpdateInstitutionRequest extends FormRequest
         ];
     }
 
+    public function hasAnyWorktimeInput(): bool
+    {
+        return filled($this->getValidatedWorktimeInput());
+    }
+
+    public function hasAnyNonCalendarInput(): bool
+    {
+        return filled($this->getValidatedNonCalendarInput());
+    }
+
+    public function getValidatedWorktimeInput(): array
+    {
+        $worktimeAttributeKeys = WorktimeValidationUtil::getWorktimeIntervalEdgesByDay()
+            ->flatten()
+            ->push('worktime_timezone')
+            ->all();
+
+        return $this->safe($worktimeAttributeKeys);
+    }
+
+    public function getValidatedNonCalendarInput(): array
+    {
+        return $this->safe(['name', 'email', 'phone', 'short_name']);
+    }
+
     public function after(): array
     {
         return [

--- a/application/app/Policies/InstitutionPolicy.php
+++ b/application/app/Policies/InstitutionPolicy.php
@@ -26,6 +26,12 @@ class InstitutionPolicy
             && Auth::hasPrivilege(PrivilegeKey::EditInstitution->value);
     }
 
+    public function updateWorktime(JwtPayloadUser $ignored, Institution $institution): bool
+    {
+        return $this->isCurrentAuthenticatedInstitution($institution)
+            && Auth::hasPrivilege(PrivilegeKey::EditInstitutionWorktime->value);
+    }
+
     public function isCurrentAuthenticatedInstitution(Institution $institution): bool
     {
         return filled($authenticatedInstitutionId = Auth::user()?->institutionId)


### PR DESCRIPTION
GitHub issue: https://github.com/keeleinstituut/tv-tolkevarav/issues/212
* I noticed that there was an oversight in the original implementation for [#212](https://github.com/keeleinstituut/tv-tolkevarav/issues/212) – namely, the `EDIT_INSTITUTION` privilege was being checked when editing worktimes, instead of `EDIT_INSTITUTION_WORKTIME`, as prescribed in [the Wiki](https://github.com/keeleinstituut/tv-tolkevarav/wiki/A-19.-Kalender#12-flow-edit-institution-user-work-days).
* This PR fixes this. It checks the `EDIT_INSTITUTION` when "normal" attributes are being updated and checks the `EDIT_INSTITUTION_WORKTIME` privilege when worktime attributes are being updated.

**N.B. Change base branch to `main` once https://github.com/keeleinstituut/tv-authorization/pull/63 is merged.**