### PR TITLE
fix(#431) - Alter collation for sorting columns.

### DIFF
--- a/application/database/migrations/2023_08_14_104838_alter_collation_for_sorting_columns.php
+++ b/application/database/migrations/2023_08_14_104838_alter_collation_for_sorting_columns.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE institutions ALTER COLUMN name TYPE TEXT COLLATE "et-EE-x-icu"');
+        DB::statement('ALTER TABLE institutions ALTER COLUMN short_name TYPE VARCHAR(3) COLLATE "et-EE-x-icu"');
+        DB::statement('ALTER TABLE departments ALTER COLUMN name TYPE TEXT COLLATE "et-EE-x-icu"');
+        DB::statement('ALTER TABLE roles ALTER COLUMN name TYPE TEXT COLLATE "et-EE-x-icu"');
+        DB::statement('ALTER TABLE users ALTER COLUMN forename TYPE TEXT COLLATE "et-EE-x-icu"');
+        DB::statement('ALTER TABLE users ALTER COLUMN surname TYPE TEXT COLLATE "et-EE-x-icu"');
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::statement('ALTER TABLE institutions ALTER COLUMN name TYPE text COLLATE "default"');
+        DB::statement('ALTER TABLE institutions ALTER COLUMN short_name TYPE VARCHAR(3) COLLATE "default"');
+        DB::statement('ALTER TABLE departments ALTER COLUMN name TYPE text COLLATE "default"');
+        DB::statement('ALTER TABLE roles ALTER COLUMN name TYPE text COLLATE "default"');
+        DB::statement('ALTER TABLE users ALTER COLUMN forename TYPE TEXT COLLATE "default"');
+        DB::statement('ALTER TABLE users ALTER COLUMN surname TYPE TEXT COLLATE "default"');
+    }
+};


### PR DESCRIPTION
Note: I used raw SQL instead of Laravel build-in altering (`$table->string('name')->collation('et-EE-x-icu')->change();`) because it doesn't work in case when changing only collation. Here is the [StackOverflow issue](https://stackoverflow.com/questions/56770416/update-column-collation-with-laravel) about it.