### PR TITLE
fix: remove assumption that is_root column exists from migrations older than is_root column

### DIFF
--- a/application/database/helpers/InsertPrivilegesMigration.php
+++ b/application/database/helpers/InsertPrivilegesMigration.php
@@ -2,8 +2,6 @@
 
 namespace Database\Helpers;
 
-use App\Models\Privilege;
-use App\Models\Role;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -22,8 +20,6 @@ abstract class InsertPrivilegesMigration extends Migration
                 ];
             }, $this->getPrivilegesKeys())
         );
-
-        self::populateRootRolesWithAllPrivileges();
     }
 
     public function down(): void
@@ -31,14 +27,6 @@ abstract class InsertPrivilegesMigration extends Migration
         DB::table('privileges')
             ->whereIn('key', $this->getPrivilegesKeys())
             ->delete();
-    }
-
-    public static function populateRootRolesWithAllPrivileges() {
-        $allPrivilegeIds = Privilege::plucK('id');
-        $rootRoles = Role::where('is_root', true)->get();
-        $rootRoles->each(function ($role) use ($allPrivilegeIds) {
-            $role->privileges()->sync($allPrivilegeIds);
-        });
     }
 
     /**

--- a/application/database/helpers/RootRoleAwareInsertPrivilegesMigration.php
+++ b/application/database/helpers/RootRoleAwareInsertPrivilegesMigration.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Helpers;
+
+use App\Models\Privilege;
+use App\Models\Role;
+
+abstract class RootRoleAwareInsertPrivilegesMigration extends InsertPrivilegesMigration
+{
+    public function up(): void
+    {
+        parent::up();
+        static::populateRootRolesWithAllPrivileges();
+    }
+
+    public static function populateRootRolesWithAllPrivileges(): void
+    {
+        $allPrivilegeIds = Privilege::plucK('id');
+        $rootRoles = Role::where('is_root', true)->get();
+        $rootRoles->each(function ($role) use ($allPrivilegeIds) {
+            $role->privileges()->sync($allPrivilegeIds);
+        });
+    }
+}

--- a/application/database/migrations/2023_06_07_122214_insert_privileges.php
+++ b/application/database/migrations/2023_06_07_122214_insert_privileges.php
@@ -1,8 +1,8 @@
 <?php
 
-use Database\Helpers\InsertPrivilegesMigration;
+use Database\Helpers\RootRoleAwareInsertPrivilegesMigration;
 
-return new class extends InsertPrivilegesMigration
+return new class extends RootRoleAwareInsertPrivilegesMigration
 {
     public function getPrivilegesKeys(): array
     {

--- a/application/database/migrations/2023_06_13_192513_insert_privileges_concerning_vendors.php
+++ b/application/database/migrations/2023_06_13_192513_insert_privileges_concerning_vendors.php
@@ -1,8 +1,8 @@
 <?php
 
-use Database\Helpers\InsertPrivilegesMigration;
+use Database\Helpers\RootRoleAwareInsertPrivilegesMigration;
 
-return new class extends InsertPrivilegesMigration
+return new class extends RootRoleAwareInsertPrivilegesMigration
 {
     public function getPrivilegesKeys(): array
     {

--- a/application/database/migrations/2023_08_17_055012_insert_privileges.php
+++ b/application/database/migrations/2023_08_17_055012_insert_privileges.php
@@ -1,8 +1,8 @@
 <?php
 
-use Database\Helpers\InsertPrivilegesMigration;
+use Database\Helpers\RootRoleAwareInsertPrivilegesMigration;
 
-return new class extends InsertPrivilegesMigration
+return new class extends RootRoleAwareInsertPrivilegesMigration
 {
     public function getPrivilegesKeys(): array
     {

--- a/application/database/migrations/2023_08_17_060915_populate_root_roles_with_all_privileges.php
+++ b/application/database/migrations/2023_08_17_060915_populate_root_roles_with_all_privileges.php
@@ -1,6 +1,6 @@
 <?php
 
-use Database\Helpers\InsertPrivilegesMigration;
+use Database\Helpers\RootRoleAwareInsertPrivilegesMigration;
 use Illuminate\Database\Migrations\Migration;
 
 return new class extends Migration
@@ -10,7 +10,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        InsertPrivilegesMigration::populateRootRolesWithAllPrivileges();
+        RootRoleAwareInsertPrivilegesMigration::populateRootRolesWithAllPrivileges();
     }
 
     /**


### PR DESCRIPTION
This fixes an issue I discovered in the migrations when I tried to run them on a clean database. I described the issue itself in [this comment](https://github.com/keeleinstituut/tv-authorization/pull/69#issuecomment-1698301293).